### PR TITLE
Generalize getSecurityId() API to getSecurity()

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ import trade from 'wstrade-api';
 * [——> trade.getCancelledOrders()](#getCancelledOrders)
 * [——> trade.cancelOrder()](#cancelOrder)
 * [——> trade.cancelPendingOrders()](#cancelPendingOrders)
+* [——> trade.getSecurity()](#getSecurity)
 * [——> trade.placeLimitBuy()](#placeLimitBuy)
 * [——> trade.placeLimitSell()](#placeLimitSell)
 

--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ Grabs all cancelled orders for the specified account under the WealthSimple Trad
 
 ## **trade**.cancelOrder(*tokens*, *orderId*) -> **Promise\<result\>**
 
-Attempts to cancels the order associated with the provided orderId.
+Attempts to cancel the order associated with the provided orderId.
 
 **Note**: The order might NOT be cancelled if it was filled by WealthSimple Trade. This has nothing to do with this wrapper; be cautious!
 
@@ -528,11 +528,11 @@ Place a cancellation order for all pending orders in the provided account.
 ]
 ```
 
-<a id="getSecurityId"></a>
+<a id="getSecurity"></a>
 
-## **trade**.getSecurityId(*tokens*, *ticker*) -> **Promise\<result\>**
+## **trade**.getSecurity(*tokens*, *ticker*) -> **Promise\<result\>**
 
-Provides the security id of the ticker (used internally by WealthSimple Trade).
+Information about a security on the WealthSimple Trade Platform.
 
 
 | Parameters|Required|
@@ -543,7 +543,10 @@ Provides the security id of the ticker (used internally by WealthSimple Trade).
 ### Return on Success (Promise.resolve())
 
 ```javascript
-'sec-XXXXXXXXXX'
+{
+    // A lot of information about the security
+    ...
+}
 ```
 
 <a id="placeLimitBuy"></a>

--- a/index.js
+++ b/index.js
@@ -141,10 +141,9 @@ var WealthSimpleTradeEndpoints = {
   },
 
   /*
-   * Provides the WealthSimple Trade security id for the security represented
-   * by the ticker.
+   * Grabs information about the security resembled by the ticker.
    */
-  SECURITY_ID: {
+  SECURITY: {
     method: "GET",
     url: "https://trade-service.wealthsimple.com/securities?query={0}",
     parameters: {
@@ -159,7 +158,7 @@ var WealthSimpleTradeEndpoints = {
         });
       }
 
-      return data.results[0].id;
+      return data.results[0];
     },
     onFailure: defaultEndpointBehaviour.onFailure
   },
@@ -542,13 +541,13 @@ var wealthsimple = {
   },
 
   /**
-   * Discovers the WealthSimple Trade security id for the provided ticker.
+   * Information about a security on the WealthSimple Trade Platform.
    *
    * @param {*} tokens The access and refresh tokens returned by a successful login.
    * @param {*} ticker The security symbol
    */
-  getSecurityId: async function getSecurityId(tokens, ticker) {
-    return handleRequest(WealthSimpleTradeEndpoints.SECURITY_ID, { ticker: ticker }, tokens);
+  getSecurity: async function getSecurity(tokens, ticker) {
+    return handleRequest(WealthSimpleTradeEndpoints.SECURITY, { ticker: ticker }, tokens);
   },
 
   /**
@@ -563,7 +562,7 @@ var wealthsimple = {
   placeLimitBuy: async function placeLimitBuy(tokens, accountId, ticker, limit, quantity) {
     return handleRequest(WealthSimpleTradeEndpoints.PLACE_ORDER, {
       accountId: accountId,
-      security_id: await wealthsimple.getSecurityId(tokens, ticker),
+      security_id: (await wealthsimple.getSecurity(tokens, ticker)).id,
       limit_price: limit,
       quantity: quantity,
       order_type: "buy_quantity",
@@ -584,7 +583,7 @@ var wealthsimple = {
   placeLimitSell: async function placeLimitSell(tokens, accountId, ticker, limit, quantity) {
     return handleRequest(WealthSimpleTradeEndpoints.PLACE_ORDER, {
       accountId: accountId,
-      security_id: await wealthsimple.getSecurityId(tokens, ticker),
+      security_id: (await wealthsimple.getSecurity(tokens, ticker)).id,
       limit_price: limit,
       quantity: quantity,
       order_type: "sell_quantity",

--- a/index.js
+++ b/index.js
@@ -286,8 +286,14 @@ var WealthSimpleTradeEndpoints = {
     onFailure: defaultEndpointBehaviour.onFailure
   }
 
-  // WealthSimple Trade API returns some custom HTTP codes
-};var wealthSimpleHttpCodes = {
+  // The maximum number of orders retrieved by the /orders API.
+};var ORDERS_PER_PAGE = 20;
+var isSuccessfulRequest = function isSuccessfulRequest(code) {
+  return httpSuccessCodes.includes(code);
+};
+
+// WealthSimple Trade API returns some custom HTTP codes
+var wealthSimpleHttpCodes = {
   ORDER_FILLED: 201
 
   // Successful HTTP codes to be used for determining the status of the request
@@ -371,13 +377,6 @@ function talk(endpoint, data, tokens) {
     headers: headers
   });
 }
-
-var isSuccessfulRequest = function isSuccessfulRequest(code) {
-  return httpSuccessCodes.includes(code);
-};
-
-// The maximum number of orders retrieved by the /orders API.
-var ORDERS_PER_PAGE = 20;
 
 var wealthsimple = {
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wstrade-api",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "WealthSimple Trade API Wrapper for JavaScript",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -266,6 +266,10 @@ const WealthSimpleTradeEndpoints = {
   }
 }
 
+// The maximum number of orders retrieved by the /orders API.
+const ORDERS_PER_PAGE = 20;
+const isSuccessfulRequest = (code) => httpSuccessCodes.includes(code);
+
 // WealthSimple Trade API returns some custom HTTP codes
 const wealthSimpleHttpCodes = {
   ORDER_FILLED: 201
@@ -353,11 +357,6 @@ function talk(endpoint, data, tokens) {
     headers: headers
   })
 }
-
-const isSuccessfulRequest = (code) => httpSuccessCodes.includes(code);
-
-// The maximum number of orders retrieved by the /orders API.
-const  ORDERS_PER_PAGE = 20;
 
 const wealthsimple = {
     

--- a/src/index.js
+++ b/src/index.js
@@ -122,10 +122,9 @@ const WealthSimpleTradeEndpoints = {
   },
 
   /*
-   * Provides the WealthSimple Trade security id for the security represented
-   * by the ticker.
+   * Grabs information about the security resembled by the ticker.
    */
-  SECURITY_ID: {
+  SECURITY: {
     method: "GET",
     url: "https://trade-service.wealthsimple.com/securities?query={0}",
     parameters: {
@@ -140,7 +139,7 @@ const WealthSimpleTradeEndpoints = {
         });
       }
 
-      return data.results[0].id
+      return data.results[0];
     },
     onFailure: defaultEndpointBehaviour.onFailure
   },
@@ -507,13 +506,13 @@ const wealthsimple = {
   },
 
   /**
-   * Discovers the WealthSimple Trade security id for the provided ticker.
+   * Information about a security on the WealthSimple Trade Platform.
    *
    * @param {*} tokens The access and refresh tokens returned by a successful login.
    * @param {*} ticker The security symbol
    */
-  getSecurityId: async (tokens, ticker) =>
-    handleRequest(WealthSimpleTradeEndpoints.SECURITY_ID, { ticker }, tokens),
+  getSecurity: async (tokens, ticker) =>
+    handleRequest(WealthSimpleTradeEndpoints.SECURITY, { ticker }, tokens),
 
   /**
    * Limit buy a security through the WealthSimple Trade application.
@@ -527,7 +526,7 @@ const wealthsimple = {
   placeLimitBuy: async(tokens, accountId, ticker, limit, quantity) =>
     handleRequest(WealthSimpleTradeEndpoints.PLACE_ORDER, {
       accountId,
-      security_id: await wealthsimple.getSecurityId(tokens, ticker),
+      security_id: (await wealthsimple.getSecurity(tokens, ticker)).id,
       limit_price: limit,
       quantity,
       order_type: "buy_quantity",
@@ -547,7 +546,7 @@ const wealthsimple = {
   placeLimitSell: async (tokens, accountId, ticker, limit, quantity) =>
     handleRequest(WealthSimpleTradeEndpoints.PLACE_ORDER, {
       accountId,
-      security_id: await wealthsimple.getSecurityId(tokens, ticker),
+      security_id: (await wealthsimple.getSecurity(tokens, ticker)).id,
       limit_price: limit,
       quantity,
       order_type: "sell_quantity",


### PR DESCRIPTION
Replaced getSecurityId() with getSecurity() to promote the utility of the API wraper. The security id is easily retrievable by doing `getSecurity().id`. (After resolving promises).