### PR TITLE
Support Custom Headers for API Calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,21 @@ After installing **wstrade-api** from the npm registry, import it into your Java
 import trade from 'wstrade-api';
 ```
 
+## Server-Side Limitation
+
+This wrapper will not work when executed on the client-side due to the underlying CORS security limitation imposed by the WealthSimple Trade endpoints.
+If you wish to build a front-end application, you will have to design an architecture where the server
+does all of the API calls.
+
 <a id="index"></a>
 
 ## Jump to
 
 * [trade.login()](#login)
 * [trade.refresh()](#refresh)
+* [trade.addHeader()](#addHeader)
+* [trade.removeHeader()](#removeHeader)
+* [trade.clearHeaders()](#clearHeaders)
 * [trade.getAccounts()](#getAccounts)
 * [trade.getAccountData()](#getAccountData)
 * [trade.getHistory()](#getHistory)
@@ -151,6 +160,46 @@ Generates a new set of access and refresh tokens.
     refresh: 'YYYY'
 }
 ```
+
+[Back to top—>](#index)
+
+<a id="addHeader"></a>
+
+## **trade**.addHeader(*name*, *value*) -> **void**
+
+
+Appends a custom header to all requests made with this wrapper.
+
+
+| Parameters|Required|    
+|----------|---------------------|
+| name |Yes|
+| value |Yes|
+
+[Back to top—>](#index)
+
+
+<a id="removeHeader"></a>
+
+## **trade**.removeHeader(*name*) -> **void**
+
+
+Removes a custom header.
+
+
+| Parameters|Required|    
+|----------|---------------------|
+| name |Yes|
+
+[Back to top—>](#index)
+
+
+<a id="clearHeaders"></a>
+
+## **trade**.clearHeaders() -> **void**
+
+
+Deletes all custom headers.
 
 [Back to top—>](#index)
 

--- a/index.js
+++ b/index.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _console;
-
 var _nodeFetch = require('node-fetch');
 
 var _nodeFetch2 = _interopRequireDefault(_nodeFetch);
@@ -353,18 +351,3 @@ var wealthsimple = {
 };
 
 exports.default = wealthsimple;
-
-
-wealthsimple.addHeader('hi', 'ahmed');
-console.log(customHeaders);
-
-wealthsimple.removeHeader('hi');
-console.log(customHeaders);
-
-wealthsimple.addHeader('hi', 'ahmed');
-wealthsimple.addHeader('see', 'ahmed');
-wealthsimple.addHeader('yeas', 'ahmed');
-(_console = console).log.apply(_console, _toConsumableArray(customHeaders));
-
-wealthsimple.clearHeaders();
-console.log(customHeaders);

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _console;
+
 var _nodeFetch = require('node-fetch');
 
 var _nodeFetch2 = _interopRequireDefault(_nodeFetch);
@@ -13,6 +15,10 @@ var _endpoints = require('./endpoints');
 var _endpoints2 = _interopRequireDefault(_endpoints);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
+var customHeaders = new _nodeFetch2.default.Headers();
 
 /*
  * Fulfill the endpoint request given the endpoint configuration, optional
@@ -70,6 +76,8 @@ function finalizeRequest(endpoint, data) {
  */
 function talk(endpoint, data, tokens) {
   var headers = new _nodeFetch2.default.Headers();
+  Object.assign(headers, customHeaders);
+
   headers.append('Content-Type', 'application/json');
 
   if (tokens) {
@@ -112,6 +120,34 @@ var wealthsimple = {
    */
   refresh: async function refresh(tokens) {
     return handleRequest(_endpoints2.default.REFRESH, { refresh_token: tokens.refresh }, tokens);
+  },
+
+  /**
+   * Appends a header name-value pair to all requests.
+   * 
+   * @param {*} name Header key
+   * @param {*} value Header value
+   */
+  addHeader: function addHeader(name, value) {
+    return customHeaders.append(name, value);
+  },
+
+  /**
+   * Removes a custom header from all requests.
+   * 
+   * @param {*} name Header key
+   */
+  removeHeader: function removeHeader(name) {
+    return customHeaders.delete(name);
+  },
+
+  /**
+   * Clears all custom headers.
+   */
+  clearHeaders: function clearHeaders() {
+    return [].concat(_toConsumableArray(customHeaders)).forEach(function (header) {
+      return customHeaders.delete(header[0]);
+    });
   },
 
   /**
@@ -317,3 +353,18 @@ var wealthsimple = {
 };
 
 exports.default = wealthsimple;
+
+
+wealthsimple.addHeader('hi', 'ahmed');
+console.log(customHeaders);
+
+wealthsimple.removeHeader('hi');
+console.log(customHeaders);
+
+wealthsimple.addHeader('hi', 'ahmed');
+wealthsimple.addHeader('see', 'ahmed');
+wealthsimple.addHeader('yeas', 'ahmed');
+(_console = console).log.apply(_console, _toConsumableArray(customHeaders));
+
+wealthsimple.clearHeaders();
+console.log(customHeaders);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wstrade-api",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "WealthSimple Trade API Wrapper for JavaScript",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -307,17 +307,3 @@ const wealthsimple = {
 }
 
 export default wealthsimple;
-
-wealthsimple.addHeader('hi', 'ahmed');
-console.log(customHeaders);
-
-wealthsimple.removeHeader('hi');
-console.log(customHeaders);
-
-wealthsimple.addHeader('hi', 'ahmed');
-wealthsimple.addHeader('see', 'ahmed');
-wealthsimple.addHeader('yeas', 'ahmed');
-console.log(...customHeaders);
-
-wealthsimple.clearHeaders();
-console.log(customHeaders);

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import fetch from 'node-fetch';
 import endpoints, { isSuccessfulRequest, ORDERS_PER_PAGE } from './endpoints';
 
+let customHeaders = new fetch.Headers();
+
 /*
  * Fulfill the endpoint request given the endpoint configuration, optional
  * data, and the authentication tokens.
@@ -58,6 +60,8 @@ function finalizeRequest(endpoint, data) {
  */
 function talk(endpoint, data, tokens) {
   let headers = new fetch.Headers();
+  Object.assign(headers, customHeaders);
+
   headers.append('Content-Type', 'application/json');
 
   if (tokens) {
@@ -65,7 +69,7 @@ function talk(endpoint, data, tokens) {
   }
 
   // Make a copy of the arguments so the original copy is not modified
-  let copy = {}
+  let copy = {};
   Object.assign(copy, data);
 
   // fill path and query parameters in the URL
@@ -96,6 +100,26 @@ const wealthsimple = {
    */
   refresh: async (tokens) =>
     handleRequest(endpoints.REFRESH, { refresh_token: tokens.refresh}, tokens),
+
+  /**
+   * Appends a header name-value pair to all requests.
+   * 
+   * @param {*} name Header key
+   * @param {*} value Header value
+   */
+  addHeader: (name, value) => customHeaders.append(name, value),
+
+  /**
+   * Removes a custom header from all requests.
+   * 
+   * @param {*} name Header key
+   */
+  removeHeader: (name) => customHeaders.delete(name),
+
+  /**
+   * Clears all custom headers.
+   */
+  clearHeaders: () => [...customHeaders].forEach(header => customHeaders.delete(header[0])),
 
   /**
    * Retrieves all account ids open under this WealthSimple Trade account.
@@ -283,3 +307,17 @@ const wealthsimple = {
 }
 
 export default wealthsimple;
+
+wealthsimple.addHeader('hi', 'ahmed');
+console.log(customHeaders);
+
+wealthsimple.removeHeader('hi');
+console.log(customHeaders);
+
+wealthsimple.addHeader('hi', 'ahmed');
+wealthsimple.addHeader('see', 'ahmed');
+wealthsimple.addHeader('yeas', 'ahmed');
+console.log(...customHeaders);
+
+wealthsimple.clearHeaders();
+console.log(customHeaders);


### PR DESCRIPTION
For whatever reason this might be needed, you are now able to add custom headers all API Wrapper calls:
* **addHeader()**: Adds a custom header to all requests
* **removeHeader()**: Removes a custom header that you added previously
* **clearHeaders()**: Removes all custom headers.