### PR TITLE
Hotfix custom headers to resolve breakage

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,17 +74,19 @@ function finalizeRequest(endpoint, data) {
  */
 function talk(endpoint, data, tokens) {
   var headers = new _nodeFetch2.default.Headers();
-  Object.assign(headers, customHeaders);
-
   headers.append('Content-Type', 'application/json');
+
+  // Apply all custom headers
+  [].concat(_toConsumableArray(customHeaders)).forEach(function (header) {
+    return headers.append.apply(headers, _toConsumableArray(header));
+  });
 
   if (tokens) {
     headers.append('Authorization', '' + tokens.access);
   }
 
   // Make a copy of the arguments so the original copy is not modified
-  var copy = {};
-  Object.assign(copy, data);
+  var copy = Object.assign({}, data);
 
   // fill path and query parameters in the URL
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wstrade-api",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "WealthSimple Trade API Wrapper for JavaScript",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -60,17 +60,17 @@ function finalizeRequest(endpoint, data) {
  */
 function talk(endpoint, data, tokens) {
   let headers = new fetch.Headers();
-  Object.assign(headers, customHeaders);
-
   headers.append('Content-Type', 'application/json');
+
+  // Apply all custom headers
+  [...customHeaders].forEach(header => headers.append(...header));
 
   if (tokens) {
     headers.append('Authorization', `${tokens.access}`)
   }
 
   // Make a copy of the arguments so the original copy is not modified
-  let copy = {};
-  Object.assign(copy, data);
+  let copy = Object.assign({}, data);
 
   // fill path and query parameters in the URL
   let { url, payload } = finalizeRequest(endpoint, copy);


### PR DESCRIPTION
The current implementation unintentionally broke the headers management of the API calls for `v0.3.0`. This version, `v0.3.1` fixes that unintended bug.