### PR TITLE
Support Positions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ does all of the API calls.
 * [trade.getBankAccounts()](#getBankAccounts)
 * [trade.getDeposits()](#getDeposits)
 * [trade.getExchangeRates()](#getExchangeRates)
+* [trade.getPositions()](#getPositions)
 * [trade.getOrdersByPage()](#getOrdersByPage)
 * [trade.getOrders()](#getOrders)
 * [trade.getPendingOrders()](#getPendingOrders)
@@ -386,6 +387,41 @@ Provides the current USD/CAD conversion rates for the WealthSimple Trade platfor
         "fx_rate": 1.xxx
     }
 }
+```
+
+[Back to top—>](#index)
+
+
+
+<a id="getPositions"></a>
+
+## **trade**.getPositions(*tokens*, *accountId*) -> **Promise\<result\>**
+
+
+Lists all active positions under the trading account associated with the account id.
+
+
+| Parameters|Required|
+|----------|---------------------|
+| tokens |Yes|
+| accountID|Yes|
+
+### Return on Success
+
+```javascript
+[
+    // Position 1 details
+    {
+        ...
+    },
+
+    // Position 2 details
+    {
+        ...
+    },
+    
+    ...
+]
 ```
 
 [Back to top—>](#index)

--- a/endpoints.js
+++ b/endpoints.js
@@ -191,6 +191,22 @@ var WealthSimpleTradeEndpoints = {
   },
 
   /*
+   * Lists all positions under a trading account.
+   */
+  POSITIONS: {
+    method: "GET",
+    url: "https://trade-service.wealthsimple.com/account/positions?account_id={0}",
+    parameters: {
+      0: "accountId"
+    },
+    onSuccess: async function onSuccess(request) {
+      var data = await request.response.json();
+      return data.results;
+    },
+    onFailure: defaultEndpointBehaviour.onFailure
+  },
+
+  /*
    * Grab a page of orders (20 orders).
    */
   ORDERS_BY_PAGE: {

--- a/index.js
+++ b/index.js
@@ -213,8 +213,22 @@ var wealthsimple = {
   },
 
   /**
+   * Lists all positions in the specified trading account under the WealthSimple Trade Account.
+   * 
+   * @param {*} tokens The access and refresh tokens returned by a successful login.
+   * @param {*}
+   */
+  getPositions: async function getPositions(tokens, accountId) {
+    return handleRequest(_endpoints2.default.POSITIONS, { accountId: accountId }, tokens);
+  },
+
+  /**
    * Collects orders (filled, pending, cancelled) for the provided page and
    * account id.
+   *
+   * @param {*} tokens The access and refresh tokens returned by a successful login.
+   * @param {*} accountId The specific account in the WealthSimple Trade account
+   * @param {*} page The orders page index to seek to
    */
   getOrdersByPage: async function getOrdersByPage(tokens, accountId, page) {
     return handleRequest(_endpoints2.default.ORDERS_BY_PAGE, {

--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ var wealthsimple = {
    * Lists all positions in the specified trading account under the WealthSimple Trade Account.
    * 
    * @param {*} tokens The access and refresh tokens returned by a successful login.
-   * @param {*}
+   * @param {*} accountId The specific account in the WealthSimple Trade account
    */
   getPositions: async function getPositions(tokens, accountId) {
     return handleRequest(_endpoints2.default.POSITIONS, { accountId: accountId }, tokens);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wstrade-api",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "WealthSimple Trade API Wrapper for JavaScript",
   "main": "index.js",
   "scripts": {

--- a/src/endpoints.js
+++ b/src/endpoints.js
@@ -173,6 +173,22 @@ const WealthSimpleTradeEndpoints = {
   },
 
   /*
+   * Lists all positions under a trading account.
+   */
+  POSITIONS: {
+    method: "GET",
+    url: "https://trade-service.wealthsimple.com/account/positions?account_id={0}",
+    parameters: {
+      0: "accountId"
+    },
+    onSuccess: async (request) => {
+      const data = await request.response.json();
+      return data.results;
+    },
+    onFailure: defaultEndpointBehaviour.onFailure
+  },
+
+  /*
    * Grab a page of orders (20 orders).
    */
   ORDERS_BY_PAGE: {

--- a/src/index.js
+++ b/src/index.js
@@ -174,10 +174,23 @@ const wealthsimple = {
    */
   getExchangeRates: async (tokens) =>
     handleRequest(endpoints.EXCHANGE_RATES, {}, tokens),
+  
+  /**
+   * Lists all positions in the specified trading account under the WealthSimple Trade Account.
+   * 
+   * @param {*} tokens The access and refresh tokens returned by a successful login.
+   * @param {*}
+   */
+  getPositions: async (tokens, accountId) =>
+    handleRequest(endpoints.POSITIONS, { accountId}, tokens),
 
   /**
    * Collects orders (filled, pending, cancelled) for the provided page and
    * account id.
+   *
+   * @param {*} tokens The access and refresh tokens returned by a successful login.
+   * @param {*} accountId The specific account in the WealthSimple Trade account
+   * @param {*} page The orders page index to seek to
    */
   getOrdersByPage: async (tokens, accountId, page) =>
     handleRequest(endpoints.ORDERS_BY_PAGE, {

--- a/src/index.js
+++ b/src/index.js
@@ -182,7 +182,7 @@ const wealthsimple = {
    * @param {*}
    */
   getPositions: async (tokens, accountId) =>
-    handleRequest(endpoints.POSITIONS, { accountId}, tokens),
+    handleRequest(endpoints.POSITIONS, { accountId }, tokens),
 
   /**
    * Collects orders (filled, pending, cancelled) for the provided page and

--- a/src/index.js
+++ b/src/index.js
@@ -179,7 +179,7 @@ const wealthsimple = {
    * Lists all positions in the specified trading account under the WealthSimple Trade Account.
    * 
    * @param {*} tokens The access and refresh tokens returned by a successful login.
-   * @param {*}
+   * @param {*} accountId The specific account in the WealthSimple Trade account
    */
   getPositions: async (tokens, accountId) =>
     handleRequest(endpoints.POSITIONS, { accountId }, tokens),


### PR DESCRIPTION
With this PR, the positions endpoint is now officially supported through the `getPositions()` API call. This API call returns a list of all positions (and details about them) held under a trading account.