### PR TITLE
Support for Market Buys and Sells

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,7 +729,7 @@ Information about a security on the WealthSimple Trade Platform.
 
 <a id="placeMarketBuy"></a>
 
-## **trade**.placeMarketBuy(*tokens*,*accountId*, *ticker*, *quantity*) -> **Promise\<result\>** ##
+## **trade**.placeMarketBuy(*tokens*, *accountId*, *ticker*, *quantity*) -> **Promise\<result\>** ##
 
 Attempts to market buy a given quantity of a security.
 
@@ -759,7 +759,7 @@ Attempts to market buy a given quantity of a security.
 
 <a id="placeLimitBuy"></a>
 
-## **trade**.placeLimitBuy(*tokens*,*accountId*, *ticker*, *limit*, *quantity*) -> **Promise\<result\>** ##
+## **trade**.placeLimitBuy(*tokens*, *accountId*, *ticker*, *limit*, *quantity*) -> **Promise\<result\>** ##
 
 Attempts to purchase a given quantity of a security at a maximum price.
 
@@ -789,7 +789,7 @@ Attempts to purchase a given quantity of a security at a maximum price.
 
 <a id="placeStopLimitBuy"></a>
 
-## **trade**.placeStopLimitBuy(*tokens*,*accountId*, *ticker*, *stop*, *limit*, *quantity*) -> **Promise\<result\>** ##
+## **trade**.placeStopLimitBuy(*tokens*, *accountId*, *ticker*, *stop*, *limit*, *quantity*) -> **Promise\<result\>** ##
 
 Attempts to stop limit purchase a given quantity of a security at the provided stop and limit prices.
 
@@ -821,7 +821,7 @@ Attempts to stop limit purchase a given quantity of a security at the provided s
 
 <a id="placeMarketSell"></a>
 
-## **trade**.placeMarketSell(*tokens*,*accountId*, *ticker*, *quantity*) -> **Promise\<result\>** ##
+## **trade**.placeMarketSell(*tokens*, *accountId*, *ticker*, *quantity*) -> **Promise\<result\>** ##
 
 Attempts to market sell a given quantity of a security.
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,10 @@ does all of the API calls.
 * [trade.cancelOrder()](#cancelOrder)
 * [trade.cancelPendingOrders()](#cancelPendingOrders)
 * [trade.getSecurity()](#getSecurity)
+* [trade.placeMarketBuy()](#placeMarketBuy)
 * [trade.placeLimitBuy()](#placeLimitBuy)
 * [trade.placeStopLimitBuy()](#placeStopLimitBuy)
+* [trade.placeMarketSell()](#placeMarketSell)
 * [trade.placeLimitSell()](#placeLimitSell)
 * [trade.placeStopLimitSell()](#placeStopLimitSell)
 
@@ -721,6 +723,37 @@ Information about a security on the WealthSimple Trade Platform.
 }
 ```
 
+
+[Back to top—>](#index)
+
+
+<a id="placeMarketBuy"></a>
+
+## **trade**.placeMarketBuy(*tokens*,*accountId*, *ticker*, *quantity*) -> **Promise\<result\>** ##
+
+Attempts to market buy a given quantity of a security.
+
+
+| Parameters|Required|
+|----------|---------------------|
+| tokens |Yes|
+| accountId |Yes|
+| ticker |Yes|
+| quantity |Yes|
+
+
+
+
+### Return on Success
+
+```javascript
+{
+    // Confirmation and details of the market buy
+    ...
+}
+```
+
+
 [Back to top—>](#index)
 
 
@@ -782,6 +815,37 @@ Attempts to stop limit purchase a given quantity of a security at the provided s
     ...
 }
 ```
+
+[Back to top—>](#index)
+
+
+<a id="placeMarketSell"></a>
+
+## **trade**.placeMarketSell(*tokens*,*accountId*, *ticker*, *quantity*) -> **Promise\<result\>** ##
+
+Attempts to market sell a given quantity of a security.
+
+
+| Parameters|Required|
+|----------|---------------------|
+| tokens |Yes|
+| accountId |Yes|
+| ticker |Yes|
+| quantity |Yes|
+
+
+
+
+### Return on Success
+
+```javascript
+{
+    // Confirmation and details of the market sell
+    ...
+}
+```
+
+
 
 [Back to top—>](#index)
 

--- a/index.js
+++ b/index.js
@@ -485,6 +485,35 @@ const wealthsimple = {
   }(),
 
   /**
+   * Market buy a security through the WealthSimple Trade application.
+   *
+   * @param {*} tokens The access and refresh tokens returned by a successful login.
+   * @param {*} accountId The account to make the transaction from
+   * @param {*} ticker The security symbol
+   * @param {*} quantity The number of securities to purchase
+   */
+  placeMarketBuy: function () {
+    var _placeMarketBuy = _asyncToGenerator(function* (tokens, accountId, ticker, quantity) {
+      return handleRequest(_endpoints.default.PLACE_ORDER, {
+        accountId,
+        security_id: (yield wealthsimple.getSecurity(tokens, ticker)).id,
+        quantity,
+        // The endpoint requires *any* limit price, even though it doesn't use it...
+        limit_price: 0.01,
+        order_type: "buy_quantity",
+        order_sub_type: "market",
+        time_in_force: "day"
+      }, tokens);
+    });
+
+    function placeMarketBuy(_x38, _x39, _x40, _x41) {
+      return _placeMarketBuy.apply(this, arguments);
+    }
+
+    return placeMarketBuy;
+  }(),
+
+  /**
    * Limit buy a security through the WealthSimple Trade application.
    *
    * @param {*} tokens The access and refresh tokens returned by a successful login.
@@ -506,7 +535,7 @@ const wealthsimple = {
       }, tokens);
     });
 
-    function placeLimitBuy(_x38, _x39, _x40, _x41, _x42) {
+    function placeLimitBuy(_x42, _x43, _x44, _x45, _x46) {
       return _placeLimitBuy.apply(this, arguments);
     }
 
@@ -545,11 +574,38 @@ const wealthsimple = {
       }, tokens);
     });
 
-    function placeStopLimitBuy(_x43, _x44, _x45, _x46, _x47, _x48) {
+    function placeStopLimitBuy(_x47, _x48, _x49, _x50, _x51, _x52) {
       return _placeStopLimitBuy.apply(this, arguments);
     }
 
     return placeStopLimitBuy;
+  }(),
+
+  /**
+   * Market sell a security through the WealthSimple Trade application.
+   *
+   * @param {*} tokens The access and refresh tokens returned by a successful login.
+   * @param {*} accountId The account to make the transaction from
+   * @param {*} ticker The security symbol
+   * @param {*} quantity The number of securities to purchase
+   */
+  placeMarketSell: function () {
+    var _placeMarketSell = _asyncToGenerator(function* (tokens, accountId, ticker, quantity) {
+      return handleRequest(_endpoints.default.PLACE_ORDER, {
+        accountId,
+        security_id: (yield wealthsimple.getSecurity(tokens, ticker)).id,
+        quantity,
+        order_type: "sell_quantity",
+        order_sub_type: "market",
+        time_in_force: "day"
+      }, tokens);
+    });
+
+    function placeMarketSell(_x53, _x54, _x55, _x56) {
+      return _placeMarketSell.apply(this, arguments);
+    }
+
+    return placeMarketSell;
   }(),
 
   /**
@@ -574,7 +630,7 @@ const wealthsimple = {
       }, tokens);
     });
 
-    function placeLimitSell(_x49, _x50, _x51, _x52, _x53) {
+    function placeLimitSell(_x57, _x58, _x59, _x60, _x61) {
       return _placeLimitSell.apply(this, arguments);
     }
 
@@ -613,7 +669,7 @@ const wealthsimple = {
       }, tokens);
     });
 
-    function placeStopLimitSell(_x54, _x55, _x56, _x57, _x58, _x59) {
+    function placeStopLimitSell(_x62, _x63, _x64, _x65, _x66, _x67) {
       return _placeStopLimitSell.apply(this, arguments);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wstrade-api",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "WealthSimple Trade API Wrapper for JavaScript",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -282,6 +282,28 @@ const wealthsimple = {
     handleRequest(endpoints.SECURITY, { ticker }, tokens),
 
   /**
+   * Market buy a security through the WealthSimple Trade application.
+   *
+   * @param {*} tokens The access and refresh tokens returned by a successful login.
+   * @param {*} accountId The account to make the transaction from
+   * @param {*} ticker The security symbol
+   * @param {*} quantity The number of securities to purchase
+   */
+  placeMarketBuy: async(tokens, accountId, ticker, quantity) =>
+    handleRequest(endpoints.PLACE_ORDER, {
+      accountId,
+      security_id: (await wealthsimple.getSecurity(tokens, ticker)).id,
+      quantity,
+
+      // The endpoint requires *any* limit price, even though it doesn't use it...
+      limit_price: 0.01,
+
+      order_type: "buy_quantity",
+      order_sub_type: "market",
+      time_in_force: "day"
+    }, tokens),
+
+  /**
    * Limit buy a security through the WealthSimple Trade application.
    *
    * @param {*} tokens The access and refresh tokens returned by a successful login.
@@ -331,6 +353,24 @@ const wealthsimple = {
       time_in_force: "day"
     }, tokens);
   },
+
+  /**
+   * Market sell a security through the WealthSimple Trade application.
+   *
+   * @param {*} tokens The access and refresh tokens returned by a successful login.
+   * @param {*} accountId The account to make the transaction from
+   * @param {*} ticker The security symbol
+   * @param {*} quantity The number of securities to purchase
+   */
+  placeMarketSell: async(tokens, accountId, ticker, quantity) =>
+    handleRequest(endpoints.PLACE_ORDER, {
+      accountId,
+      security_id: (await wealthsimple.getSecurity(tokens, ticker)).id,
+      quantity,
+      order_type: "sell_quantity",
+      order_sub_type: "market",
+      time_in_force: "day"
+    }, tokens),
 
   /**
    * Limit sell a security through the WealthSimple Trade application.


### PR DESCRIPTION
In this PR, I figured out how to support Market buys and sells through the endpoints. Interestingly, the market buy API requires any limit price to be set, even though it's not used. So i just hardcoded it to 0.01.