### PR TITLE
Resolve ambiguous securities via getSecurity()

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,10 +754,17 @@ Place a cancellation order for all pending orders in the provided account.
 Information about a security on the WealthSimple Trade Platform.
 
 
-| Parameters|Required|
-|----------|---------------------|
-| tokens |Yes|
-| ticker |Yes|
+| Parameters|Required|Notes|
+|----------|---------------------|-|
+| tokens |Yes| |
+| ticker |Yes| The exchange the security trades on may be included after a colon. For example, `RMD:NYSE`|
+
+The `ticker` parameter may also be an object with the following keys:
+| Key | Required | Notes |
+| --- | -------- | ----- |
+| symbol | Yes | See the `ticker` parameter above. If an exchange is included, it must not conflict with an exchange below. |
+| exchange | No | The exchange the security trades on. |
+| id | No | The internal WealthSimple ID of the security |
 
 ### Return on Success
 

--- a/README.md
+++ b/README.md
@@ -756,6 +756,16 @@ Place a cancellation order for all pending orders in the provided account.
 
 Information about a security on the WealthSimple Trade Platform.
 
+##### Specifying an exchange
+You are allowed to specify the exchange for securities as part of the `ticker` parameter through a `<symbol>:<exchange>` postfixing format. The supported exchanges id are:
+* **NASDAQ** (NASDAQ exchange)
+* **TSX** (Toronto Stock exchange)
+* **TSX-V** (Toronto Stock exchange (Venture))
+* **NYSE** (New York Stock exchange)
+
+For example, `PSI` trades on the NYSE and TSX stock exchanges. If you wish to retrieve the TSX stock, specify the ticker as `PSI:TSX`. Otherwise, specify the ticker as `PSI:NYSE`.
+
+You could also specify the `ticker` parameter as an object if you prefer not to deal with the string postfixing technique. Back to the previous example for the TSX version of `PSI`, you can specify the ticker parameter as `{symbol: "PSI", exchange: "TSX"}`.
 
 | Parameters|Required|Notes|
 |----------|---------------------|-|
@@ -974,6 +984,7 @@ We use [SemVer](http://semver.org/) for versioning. For the versions available, 
 ## Authors
 
 * **Ahmed Sakr** - *Owner* - [@ahmedsakr](https://github.com/ahmedsakr)
+* **Mitchell Sawatzky** - *Contributor* - [@bufutda](https://github.com/bufutda)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -765,9 +765,9 @@ Information about a security on the WealthSimple Trade Platform.
 The `ticker` parameter may also be an object with the following keys:
 | Key | Required | Notes |
 | --- | -------- | ----- |
-| symbol | Yes | See the `ticker` parameter above. If an exchange is included, it must not conflict with an exchange below. |
+| symbol | Yes | See the `ticker` parameter above. |
 | exchange | No | The exchange the security trades on. |
-| id | No | The internal WealthSimple ID of the security |
+| id | No | The internal WealthSimple ID of the security. |
 
 ### Return on Success
 

--- a/endpoints.js
+++ b/endpoints.js
@@ -253,7 +253,7 @@ const WealthSimpleTradeEndpoints = {
           });
         }
 
-        return data.results[0];
+        return data.results;
       });
 
       function onSuccess(_x9) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -148,7 +148,7 @@ declare namespace Trade {
      * @param {*} accountId The specific account in the WealthSimple Trade account
      * @param {*} ticker (optional) The security symbol
      */
-    function getPendingOrders(tokens: AuthTokens, accountId: string, ticker?: string): Promise<any>;
+    function getPendingOrders(tokens: AuthTokens, accountId: string, ticker?: string | SecurityIdentifier): Promise<any>;
   
     /**
      * Retrieves filled orders for the specified security in the account.
@@ -157,7 +157,7 @@ declare namespace Trade {
      * @param {*} accountId The specific account in the WealthSimple Trade account
      * @param {*} ticker (optional) The security symbol
      */
-    function getFilledOrders(tokens: AuthTokens, accountId: string, ticker?: string): Promise<any>;
+    function getFilledOrders(tokens: AuthTokens, accountId: string, ticker?: string | SecurityIdentifier): Promise<any>;
 
     /**
      * Retrieves cancelled orders for the specified security in the account.
@@ -166,7 +166,7 @@ declare namespace Trade {
      * @param {*} accountId The specific account in the WealthSimple Trade account
      * @param {*} ticker (optional) The security symbol
      */
-    function getCancelledOrders(tokens: AuthTokens, accountId: string, ticker?: string): Promise<any>;
+    function getCancelledOrders(tokens: AuthTokens, accountId: string, ticker?: string | SecurityIdentifier): Promise<any>;
 
     /**
      * Cancels the pending order specified by the order id.
@@ -201,7 +201,7 @@ declare namespace Trade {
      * @param {*} ticker The security symbol
      * @param {*} quantity The number of securities to purchase
      */
-    function placeMarketBuy(tokens: AuthTokens, accountId: string, ticker: string, quantity: number): Promise<any>;
+    function placeMarketBuy(tokens: AuthTokens, accountId: string, ticker: string | SecurityIdentifier, quantity: number): Promise<any>;
 
     /**
      * Limit buy a security through the WealthSimple Trade application.
@@ -213,7 +213,7 @@ declare namespace Trade {
      * @param {*} quantity The number of securities to purchase
      */
     function placeLimitBuy(tokens: AuthTokens,
-        accountId: string, ticker: string, limit: number, quantity: number): Promise<any>;
+        accountId: string, ticker: string | SecurityIdentifier, limit: number, quantity: number): Promise<any>;
 
     /**
      * Stop limit buy a security through the WealthSimple Trade application.
@@ -226,7 +226,7 @@ declare namespace Trade {
      * @param {*} quantity The number of securities to purchase
      */
     function placeStopLimitBuy(tokens: AuthTokens,
-        accountId: string, ticker: string, stop: number, limit: number, quantity: number): Promise<any>;
+        accountId: string, ticker: string | SecurityIdentifier, stop: number, limit: number, quantity: number): Promise<any>;
 
     /**
      * Market sell a security through the WealthSimple Trade application.
@@ -236,7 +236,7 @@ declare namespace Trade {
      * @param {*} ticker The security symbol
      * @param {*} quantity The number of securities to purchase
      */
-    function placeMarketSell(tokens: AuthTokens, accountId: string, ticker: string, quantity: number): Promise<any>;
+    function placeMarketSell(tokens: AuthTokens, accountId: string, ticker: string | SecurityIdentifier, quantity: number): Promise<any>;
 
     /**
      * Limit sell a security through the WealthSimple Trade application.
@@ -248,7 +248,7 @@ declare namespace Trade {
      * @param {*} quantity The number of securities to sell
      */
     function placeLimitSell(tokens: AuthTokens,
-        accountId: string, ticker: string, limit: number, quantity: number): Promise<any>;
+        accountId: string, ticker: string | SecurityIdentifier, limit: number, quantity: number): Promise<any>;
 
     /**
      * Stop limit sell a security through the WealthSimple Trade application.
@@ -261,7 +261,7 @@ declare namespace Trade {
      * @param {*} quantity The number of securities to sell
      */
     function placeStopLimitSell(tokens: AuthTokens,
-        accountId: string, ticker: string, stop: number, limit: number, quantity: number): Promise<any>;
+        accountId: string, ticker: string | SecurityIdentifier, stop: number, limit: number, quantity: number): Promise<any>;
 }
 
 export default Trade;

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ export type HistoryInterval = '1d'|'1w'|'1m'|'3m'|'1y';
 export type SecurityIdentifier = {
     symbol: string,
     exchange?: string,
-    string?: id
+    id?: string
 };
 
 declare namespace Trade {

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,8 +8,7 @@ export type HistoryInterval = '1d'|'1w'|'1m'|'3m'|'1y';
 /**
  * Identifies a security.
  *
- * @param {string} symbol The security symbol. An exchange may be added as a suffix, separated from the symbol with a colon.
- *                        If an exchange suffix is present, then ticker.exchange may only be passed if it references the same exchange.
+ * @param {string} symbol The security symbol.
  * @param {string} [exchange] (optional) the exchange the security trades in
  * @param {string} [id] (optional) The internal WealthSimple Trade security ID
  */
@@ -189,7 +188,7 @@ declare namespace Trade {
      * Information about a security on the WealthSimple Trade Platform.
      *
      * @param {*} tokens The access and refresh tokens returned by a successful login.
-     * @param {string|object} ticker The security symbol. An exchange may be added as a suffix, separated from the symbol with a colon.
+     * @param {string|object} ticker The security symbol. An exchange may be added as a suffix, separated from the symbol with a colon. For example, AAPL:NASDAQ, ENB:TSX
      */
     function getSecurity(tokens: AuthTokens, ticker: string | SecurityIdentifier): Promise<any>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,20 @@ export type AuthTokens = {
 
 export type HistoryInterval = '1d'|'1w'|'1m'|'3m'|'1y';
 
+/**
+ * Identifies a security.
+ *
+ * @param {string} symbol The security symbol. An exchange may be added as a suffix, separated from the symbol with a colon.
+ *                        If an exchange suffix is present, then ticker.exchange may only be passed if it references the same exchange.
+ * @param {string} [exchange] (optional) the exchange the security trades in
+ * @param {string} [id] (optional) The internal WealthSimple Trade security ID
+ */
+export type SecurityIdentifier = {
+    symbol: string,
+    exchange?: string,
+    string?: id
+};
+
 declare namespace Trade {
 
     // The standard failure return for all API calls
@@ -170,15 +184,14 @@ declare namespace Trade {
      */
     function cancelPendingOrders(tokens: AuthTokens, accountId: string): Promise<any>;
 
+
     /**
      * Information about a security on the WealthSimple Trade Platform.
      *
      * @param {*} tokens The access and refresh tokens returned by a successful login.
-     * @param {*} ticker The security symbol
-     * @param {*} exchange (optional) The exchange the security trades in
-     * @param {*} id (optional) The internal WealthSimple Trade security ID
+     * @param {string|object} ticker The security symbol. An exchange may be added as a suffix, separated from the symbol with a colon.
      */
-    function getSecurity(tokens: AuthTokens, ticker: string, exchange?: string, id?: string): Promise<any>;
+    function getSecurity(tokens: AuthTokens, ticker: string | SecurityIdentifier): Promise<any>;
 
     /**
      * Market buy a security through the WealthSimple Trade application.

--- a/index.d.ts
+++ b/index.d.ts
@@ -175,8 +175,10 @@ declare namespace Trade {
      *
      * @param {*} tokens The access and refresh tokens returned by a successful login.
      * @param {*} ticker The security symbol
+     * @param {*} exchange (optional) The exchange the security trades in
+     * @param {*} id (optional) The internal WealthSimple Trade security ID
      */
-    function getSecurity(tokens: AuthTokens, ticker: string): Promise<any>;
+    function getSecurity(tokens: AuthTokens, ticker: string, exchange?: string, id?: string): Promise<any>;
 
     /**
      * Market buy a security through the WealthSimple Trade application.

--- a/index.js
+++ b/index.js
@@ -485,9 +485,8 @@ const wealthsimple = {
    * Information about a security on the WealthSimple Trade Platform.
    *
    * @param {*} tokens The access and refresh tokens returned by a successful login.
-   * @param {string|object} ticker The security symbol. An exchange may be added as a suffix, separated from the symbol with a colon.
-   * @param {string} ticker.symbol The security symbol. An exchange may be added as a suffix, separated from the symbol with a colon.
-   *                               If an exchange suffix is present, then ticker.exchange may only be passed if it references the same exchange.
+   * @param {string|object} ticker The security symbol. An exchange may be added as a suffix, separated from the symbol with a colon, for example: AAPL:NASDAQ, ENB:TSX
+   * @param {string} ticker.symbol The security symbol.
    * @param {string} [ticker.exchange] (optional) the exchange the security trades in
    * @param {string} [ticker.id] (optional) The internal WealthSimple Trade security ID
    */
@@ -497,19 +496,11 @@ const wealthsimple = {
         ticker = {
           symbol: ticker
         };
-      }
+        let tickerParts = ticker.symbol.split(':');
 
-      let tickerParts = ticker.symbol.split(':');
-
-      if (tickerParts.length > 2) {
-        return Promise.reject({
-          reason: `Illegal ticker: ${ticker.symbol}`
-        });
-      } else if (tickerParts.length === 2) {
-        // ticker is exchange suffixed
-        if (ticker.exchange && tickerParts[1] !== ticker.exchange) {
+        if (tickerParts.length > 2) {
           return Promise.reject({
-            reason: `Exchanges provided conflict: ${ticker.exchange}, ${tickerParts[1]}`
+            reason: `Illegal ticker: ${ticker.symbol}`
           });
         }
 

--- a/index.js
+++ b/index.js
@@ -485,23 +485,49 @@ const wealthsimple = {
    * Information about a security on the WealthSimple Trade Platform.
    *
    * @param {*} tokens The access and refresh tokens returned by a successful login.
-   * @param {*} ticker The security symbol
-   * @param {*} [exchange] The exchange the security trades in
-   * @param {*} [id] The internal WealthSimple Trade security ID
+   * @param {string|object} ticker The security symbol. An exchange may be added as a suffix, separated from the symbol with a colon.
+   * @param {string} ticker.symbol The security symbol. An exchange may be added as a suffix, separated from the symbol with a colon.
+   *                               If an exchange suffix is present, then ticker.exchange may only be passed if it references the same exchange.
+   * @param {string} [ticker.exchange] (optional) the exchange the security trades in
+   * @param {string} [ticker.id] (optional) The internal WealthSimple Trade security ID
    */
   getSecurity: function () {
-    var _getSecurity = _asyncToGenerator(function* (tokens, ticker, exchange, id) {
-      let queryResult = yield handleRequest(_endpoints.default.SECURITY, {
-        ticker
-      }, tokens);
-      queryResult = queryResult.filter(security => security.stock.symbol === ticker);
-
-      if (exchange) {
-        queryResult = queryResult.filter(security => security.stock.primary_exchange === exchange);
+    var _getSecurity = _asyncToGenerator(function* (tokens, ticker) {
+      if (typeof ticker === 'string') {
+        ticker = {
+          symbol: ticker
+        };
       }
 
-      if (id) {
-        queryResult = queryResult.filter(security => security.id === id);
+      let tickerParts = ticker.symbol.split(':');
+
+      if (tickerParts.length > 2) {
+        return Promise.reject({
+          reason: `Illegal ticker: ${ticker.symbol}`
+        });
+      } else if (tickerParts.length === 2) {
+        // ticker is exchange suffixed
+        if (ticker.exchange && tickerParts[1] !== ticker.exchange) {
+          return Promise.reject({
+            reason: `Exchanges provided conflict: ${ticker.exchange}, ${tickerParts[1]}`
+          });
+        }
+
+        ticker.exchange = tickerParts[1];
+        ticker.symbol = tickerParts[0];
+      }
+
+      let queryResult = yield handleRequest(_endpoints.default.SECURITY, {
+        ticker: ticker.symbol
+      }, tokens);
+      queryResult = queryResult.filter(security => security.stock.symbol === ticker.symbol);
+
+      if (ticker.exchange) {
+        queryResult = queryResult.filter(security => security.stock.primary_exchange === ticker.exchange);
+      }
+
+      if (ticker.id) {
+        queryResult = queryResult.filter(security => security.id === ticker.id);
       }
 
       if (queryResult.length > 1) {
@@ -517,7 +543,7 @@ const wealthsimple = {
       return queryResult[0];
     });
 
-    function getSecurity(_x37, _x38, _x39, _x40) {
+    function getSecurity(_x37, _x38) {
       return _getSecurity.apply(this, arguments);
     }
 
@@ -546,7 +572,7 @@ const wealthsimple = {
       }, tokens);
     });
 
-    function placeMarketBuy(_x41, _x42, _x43, _x44) {
+    function placeMarketBuy(_x39, _x40, _x41, _x42) {
       return _placeMarketBuy.apply(this, arguments);
     }
 
@@ -575,7 +601,7 @@ const wealthsimple = {
       }, tokens);
     });
 
-    function placeLimitBuy(_x45, _x46, _x47, _x48, _x49) {
+    function placeLimitBuy(_x43, _x44, _x45, _x46, _x47) {
       return _placeLimitBuy.apply(this, arguments);
     }
 
@@ -614,7 +640,7 @@ const wealthsimple = {
       }, tokens);
     });
 
-    function placeStopLimitBuy(_x50, _x51, _x52, _x53, _x54, _x55) {
+    function placeStopLimitBuy(_x48, _x49, _x50, _x51, _x52, _x53) {
       return _placeStopLimitBuy.apply(this, arguments);
     }
 
@@ -641,7 +667,7 @@ const wealthsimple = {
       }, tokens);
     });
 
-    function placeMarketSell(_x56, _x57, _x58, _x59) {
+    function placeMarketSell(_x54, _x55, _x56, _x57) {
       return _placeMarketSell.apply(this, arguments);
     }
 
@@ -670,7 +696,7 @@ const wealthsimple = {
       }, tokens);
     });
 
-    function placeLimitSell(_x60, _x61, _x62, _x63, _x64) {
+    function placeLimitSell(_x58, _x59, _x60, _x61, _x62) {
       return _placeLimitSell.apply(this, arguments);
     }
 
@@ -709,7 +735,7 @@ const wealthsimple = {
       }, tokens);
     });
 
-    function placeStopLimitSell(_x65, _x66, _x67, _x68, _x69, _x70) {
+    function placeStopLimitSell(_x63, _x64, _x65, _x66, _x67, _x68) {
       return _placeStopLimitSell.apply(this, arguments);
     }
 

--- a/index.js
+++ b/index.js
@@ -486,15 +486,38 @@ const wealthsimple = {
    *
    * @param {*} tokens The access and refresh tokens returned by a successful login.
    * @param {*} ticker The security symbol
+   * @param {*} [exchange] The exchange the security trades in
+   * @param {*} [id] The internal WealthSimple Trade security ID
    */
   getSecurity: function () {
-    var _getSecurity = _asyncToGenerator(function* (tokens, ticker) {
-      return handleRequest(_endpoints.default.SECURITY, {
+    var _getSecurity = _asyncToGenerator(function* (tokens, ticker, exchange, id) {
+      let queryResult = yield handleRequest(_endpoints.default.SECURITY, {
         ticker
       }, tokens);
+      queryResult = queryResult.filter(security => security.stock.symbol === ticker);
+
+      if (exchange) {
+        queryResult = queryResult.filter(security => security.stock.primary_exchange === exchange);
+      }
+
+      if (id) {
+        queryResult = queryResult.filter(security => security.id === id);
+      }
+
+      if (queryResult.length > 1) {
+        return Promise.reject({
+          reason: 'Multiple securities matched query.'
+        });
+      } else if (queryResult.length === 0) {
+        return Promise.reject({
+          reason: 'No securities matched query.'
+        });
+      }
+
+      return queryResult[0];
     });
 
-    function getSecurity(_x37, _x38) {
+    function getSecurity(_x37, _x38, _x39, _x40) {
       return _getSecurity.apply(this, arguments);
     }
 
@@ -523,7 +546,7 @@ const wealthsimple = {
       }, tokens);
     });
 
-    function placeMarketBuy(_x39, _x40, _x41, _x42) {
+    function placeMarketBuy(_x41, _x42, _x43, _x44) {
       return _placeMarketBuy.apply(this, arguments);
     }
 
@@ -552,7 +575,7 @@ const wealthsimple = {
       }, tokens);
     });
 
-    function placeLimitBuy(_x43, _x44, _x45, _x46, _x47) {
+    function placeLimitBuy(_x45, _x46, _x47, _x48, _x49) {
       return _placeLimitBuy.apply(this, arguments);
     }
 
@@ -591,7 +614,7 @@ const wealthsimple = {
       }, tokens);
     });
 
-    function placeStopLimitBuy(_x48, _x49, _x50, _x51, _x52, _x53) {
+    function placeStopLimitBuy(_x50, _x51, _x52, _x53, _x54, _x55) {
       return _placeStopLimitBuy.apply(this, arguments);
     }
 
@@ -618,7 +641,7 @@ const wealthsimple = {
       }, tokens);
     });
 
-    function placeMarketSell(_x54, _x55, _x56, _x57) {
+    function placeMarketSell(_x56, _x57, _x58, _x59) {
       return _placeMarketSell.apply(this, arguments);
     }
 
@@ -647,7 +670,7 @@ const wealthsimple = {
       }, tokens);
     });
 
-    function placeLimitSell(_x58, _x59, _x60, _x61, _x62) {
+    function placeLimitSell(_x60, _x61, _x62, _x63, _x64) {
       return _placeLimitSell.apply(this, arguments);
     }
 
@@ -686,7 +709,7 @@ const wealthsimple = {
       }, tokens);
     });
 
-    function placeStopLimitSell(_x63, _x64, _x65, _x66, _x67, _x68) {
+    function placeStopLimitSell(_x65, _x66, _x67, _x68, _x69, _x70) {
       return _placeStopLimitSell.apply(this, arguments);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wstrade-api",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "WealthSimple Trade API Wrapper for JavaScript",
   "main": "index.js",
   "scripts": {

--- a/src/endpoints.js
+++ b/src/endpoints.js
@@ -181,7 +181,7 @@ const WealthSimpleTradeEndpoints = {
         });
       }
 
-      return data.results[0];
+      return data.results;
     },
     onFailure: defaultEndpointBehaviour.onFailure
   },

--- a/src/index.js
+++ b/src/index.js
@@ -284,9 +284,8 @@ const wealthsimple = {
    * Information about a security on the WealthSimple Trade Platform.
    *
    * @param {*} tokens The access and refresh tokens returned by a successful login.
-   * @param {string|object} ticker The security symbol. An exchange may be added as a suffix, separated from the symbol with a colon.
-   * @param {string} ticker.symbol The security symbol. An exchange may be added as a suffix, separated from the symbol with a colon.
-   *                               If an exchange suffix is present, then ticker.exchange may only be passed if it references the same exchange.
+   * @param {string|object} ticker The security symbol. An exchange may be added as a suffix, separated from the symbol with a colon, for example: AAPL:NASDAQ, ENB:TSX
+   * @param {string} ticker.symbol The security symbol.
    * @param {string} [ticker.exchange] (optional) the exchange the security trades in
    * @param {string} [ticker.id] (optional) The internal WealthSimple Trade security ID
    */
@@ -294,16 +293,10 @@ const wealthsimple = {
     if (typeof (ticker) === 'string') {
       ticker = {
         symbol: ticker
-      }
-    }
-
-    let tickerParts = ticker.symbol.split(':');
-    if (tickerParts.length > 2) {
-      return Promise.reject({reason: `Illegal ticker: ${ticker.symbol}`});
-    } else if (tickerParts.length === 2) {
-      // ticker is exchange suffixed
-      if (ticker.exchange && tickerParts[1] !== ticker.exchange) {
-        return Promise.reject({reason: `Exchanges provided conflict: ${ticker.exchange}, ${tickerParts[1]}`});
+      };
+      let tickerParts = ticker.symbol.split(':');
+      if (tickerParts.length > 2) {
+        return Promise.reject({reason: `Illegal ticker: ${ticker.symbol}`});
       }
       ticker.exchange = tickerParts[1];
       ticker.symbol = tickerParts[0];

--- a/src/index.js
+++ b/src/index.js
@@ -285,9 +285,28 @@ const wealthsimple = {
    *
    * @param {*} tokens The access and refresh tokens returned by a successful login.
    * @param {*} ticker The security symbol
+   * @param {*} [exchange] The exchange the security trades in
+   * @param {*} [id] The internal WealthSimple Trade security ID
    */
-  getSecurity: async (tokens, ticker) =>
-    handleRequest(endpoints.SECURITY, { ticker }, tokens),
+  getSecurity: async (tokens, ticker, exchange, id) => {
+    let queryResult = await handleRequest(endpoints.SECURITY, { ticker }, tokens);
+    queryResult = queryResult.filter(security => security.stock.symbol === ticker);
+
+    if (exchange) {
+      queryResult = queryResult.filter(security => security.stock.primary_exchange === exchange);
+    }
+    if (id) {
+      queryResult = queryResult.filter(security => security.id === id);
+    }
+
+    if (queryResult.length > 1) {
+      return Promise.reject({reason: 'Multiple securities matched query.'});
+    } else if (queryResult.length === 0) {
+      return Promise.reject({reason: 'No securities matched query.'});
+    }
+
+    return queryResult[0];
+  },
 
   /**
    * Market buy a security through the WealthSimple Trade application.


### PR DESCRIPTION
Leaving the `exchange` and `id` arguments optional maintains backwards compatibility. The only difference is the promise will now be rejected if there are ambiguous results.

A further update to allow the same filters to be passed to the endpoints that internally call `getSecurity` is necessary.