### PR TITLE
Add observation of maximum hourly trades

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ illegitimate personal gains. For example, [Spoofing](https://en.wikipedia.org/wi
 My recommendation is to be very conservative on how many orders you place within a small timeframe. I have no idea what
 the maximum amount of orders is by any timeframe, but if you have a gut feeling that it is too much, then it is too much.
 
+A user of wstrade-api has observed that trades in excess of 7 per hour are rejected by the WealthSimple Trade servers. You
+can use this observation as a baseline of how many trade you can perform on an hourly basis.
+
 ## Getting Started
 
 Before playing with **wstrade-api**, you must have a valid

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ My recommendation is to be very conservative on how many orders you place within
 the maximum amount of orders is by any timeframe, but if you have a gut feeling that it is too much, then it is too much.
 
 A user of wstrade-api has observed that trades in excess of 7 per hour are rejected by the WealthSimple Trade servers. You
-can use this observation as a baseline of how many trade you can perform on an hourly basis.
+can use this observation as a baseline of how many trades you can perform on an hourly basis.
 
 ## Getting Started
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wstrade-api",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "WealthSimple Trade API Wrapper for JavaScript",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
@austingreisman has observed that trades in excess of 7 per hour are rejected by the WealthSimple Trade servers.