### PR TITLE
Upgrade buying and selling APIs to new WS Trade data architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ the maximum amount of orders is by any timeframe, but if you have a gut feeling 
 A user of wstrade-api has observed that trades in excess of 7 per hour are rejected by the WealthSimple Trade servers. You
 can use this observation as a baseline of how many trades you can perform on an hourly basis.
 
+## Deprecated Versions
+
+`<= v0.9.0` is deprecated due to a WS Trade architecture change in handling buy and sell APIs. These old versions
+will work for everything except buying and selling. Upgrade to a later version if you wish to use the buying and selling
+APIs.
+
 ## Getting Started
 
 Before playing with **wstrade-api**, you must have a valid

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ can use this observation as a baseline of how many trades you can perform on an 
 
 ## Deprecated Versions
 
-`<= v0.9.0` is deprecated due to a WS Trade architecture change in handling buy and sell APIs. These old versions
+* Versions `<= v0.9.0` are deprecated due to a WS Trade architecture change in handling buy and sell APIs. These old versions
 will work for everything except buying and selling. Upgrade to a later version if you wish to use the buying and selling
 APIs.
 

--- a/endpoints.js
+++ b/endpoints.js
@@ -427,10 +427,7 @@ const WealthSimpleTradeEndpoints = {
    */
   PLACE_ORDER: {
     method: "POST",
-    url: "https://trade-service.wealthsimple.com/orders?account_id={0}",
-    parameters: {
-      0: "accountId"
-    },
+    url: "https://trade-service.wealthsimple.com/orders",
     onSuccess: defaultEndpointBehaviour.onSuccess,
     onFailure: defaultEndpointBehaviour.onFailure
   }

--- a/index.js
+++ b/index.js
@@ -559,7 +559,8 @@ const wealthsimple = {
         limit_price: 0.01,
         order_type: "buy_quantity",
         order_sub_type: "market",
-        time_in_force: "day"
+        time_in_force: "day",
+        account_id: accountId
       }, tokens);
     });
 
@@ -588,7 +589,8 @@ const wealthsimple = {
         quantity,
         order_type: "buy_quantity",
         order_sub_type: "limit",
-        time_in_force: "day"
+        time_in_force: "day",
+        account_id: accountId
       }, tokens);
     });
 
@@ -627,7 +629,8 @@ const wealthsimple = {
         quantity,
         order_type: "buy_quantity",
         order_sub_type: "stop_limit",
-        time_in_force: "day"
+        time_in_force: "day",
+        account_id: accountId
       }, tokens);
     });
 
@@ -654,7 +657,8 @@ const wealthsimple = {
         quantity,
         order_type: "sell_quantity",
         order_sub_type: "market",
-        time_in_force: "day"
+        time_in_force: "day",
+        account_id: accountId
       }, tokens);
     });
 
@@ -683,7 +687,8 @@ const wealthsimple = {
         quantity,
         order_type: "sell_quantity",
         order_sub_type: "limit",
-        time_in_force: "day"
+        time_in_force: "day",
+        account_id: accountId
       }, tokens);
     });
 
@@ -722,7 +727,8 @@ const wealthsimple = {
         quantity,
         order_type: "sell_quantity",
         order_sub_type: "stop_limit",
-        time_in_force: "day"
+        time_in_force: "day",
+        account_id: accountId
       }, tokens);
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wstrade-api",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "WealthSimple Trade API Wrapper for JavaScript",
   "main": "index.js",
   "scripts": {

--- a/src/endpoints.js
+++ b/src/endpoints.js
@@ -313,10 +313,7 @@ const WealthSimpleTradeEndpoints = {
    */
   PLACE_ORDER: {
     method: "POST",
-    url: "https://trade-service.wealthsimple.com/orders?account_id={0}",
-    parameters: {
-      0: "accountId"
-    },
+    url: "https://trade-service.wealthsimple.com/orders",
     onSuccess: defaultEndpointBehaviour.onSuccess,
     onFailure: defaultEndpointBehaviour.onFailure
   }

--- a/src/index.js
+++ b/src/index.js
@@ -340,7 +340,8 @@ const wealthsimple = {
 
       order_type: "buy_quantity",
       order_sub_type: "market",
-      time_in_force: "day"
+      time_in_force: "day",
+      account_id: accountId
     }, tokens),
 
   /**
@@ -360,7 +361,8 @@ const wealthsimple = {
       quantity,
       order_type: "buy_quantity",
       order_sub_type: "limit",
-      time_in_force: "day"
+      time_in_force: "day",
+      account_id: accountId
     }, tokens),
 
   /**
@@ -390,7 +392,8 @@ const wealthsimple = {
       quantity,
       order_type: "buy_quantity",
       order_sub_type: "stop_limit",
-      time_in_force: "day"
+      time_in_force: "day",
+      account_id: accountId
     }, tokens);
   },
 
@@ -409,7 +412,8 @@ const wealthsimple = {
       quantity,
       order_type: "sell_quantity",
       order_sub_type: "market",
-      time_in_force: "day"
+      time_in_force: "day",
+      account_id: accountId
     }, tokens),
 
   /**
@@ -429,7 +433,8 @@ const wealthsimple = {
       quantity,
       order_type: "sell_quantity",
       order_sub_type: "limit",
-      time_in_force: "day"
+      time_in_force: "day",
+      account_id: accountId
     }, tokens),
 
   /**
@@ -459,7 +464,8 @@ const wealthsimple = {
       quantity,
       order_type: "sell_quantity",
       order_sub_type: "stop_limit",
-      time_in_force: "day"
+      time_in_force: "day",
+      account_id: accountId
     }, tokens);
   }
 }


### PR DESCRIPTION
WS Trade has moved to a new method of handling `account_id`-- instead of it being a query parameter, it is specified in the body now.